### PR TITLE
Update the type of the exit status code

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/09 12:55:28 by mcourtoi          #+#    #+#             */
-/*   Updated: 2023/03/10 20:01:30 by jodufour         ###   ########.fr       */
+/*   Updated: 2023/03/11 00:09:23 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@
 # include <readline/readline.h>
 # include <readline/history.h>
 
-extern int					g_exit_code;
+extern uint8_t	g_exit_code;
 
 void	free_tab(char **tab);
 void	handle_signal(int sig);

--- a/src/main.c
+++ b/src/main.c
@@ -6,13 +6,13 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/09 12:48:12 by mcourtoi          #+#    #+#             */
-/*   Updated: 2023/03/10 20:03:42 by jodufour         ###   ########.fr       */
+/*   Updated: 2023/03/11 00:09:55 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	g_exit_code = 0;
+uint8_t	g_exit_code = 0U;
 
 inline static int	__usage_error(char const *const prog_name)
 					__attribute__((nonnull(1)));


### PR DESCRIPTION
The made changes are related to the issue https://github.com/Saphirac/minishell/issues/12.
The global variable `g_exit_code` was previously typed as an `int`. This has been changed to the type `uint8_t`.