### PR TITLE
Prevent exiting the shell when any error occurs in builtins

### DIFF
--- a/include/lookup_builtin.h
+++ b/include/lookup_builtin.h
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/08 20:29:22 by jodufour          #+#    #+#             */
-/*   Updated: 2023/03/31 05:16:17 by jodufour         ###   ########.fr       */
+/*   Updated: 2023/04/03 06:55:51 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,7 @@
 # include "minishell.h"
 
 typedef struct s_builtin	t_builtin;
-typedef int					(*t_func0)(t_env_lst *const, t_token const *const);
+typedef void				(*t_func0)(t_env_lst *const, t_token const *const);
 
 struct s_builtin
 {
@@ -24,20 +24,20 @@ struct s_builtin
 	t_func0 const		func;
 };
 
-int	builtin_cd(t_env_lst *const env, t_token const *token)
-	__attribute__((nonnull (1)));
-int	builtin_echo(t_env_lst *const env, t_token const *token)
-	__attribute__((nonnull (1)));
-int	builtin_env(t_env_lst *const env, t_token const *token)
-	__attribute__((nonnull (1)));
-int	builtin_exit(t_env_lst *const env, t_token const *token)
-	__attribute__((nonnull (1)));
-int	builtin_export(t_env_lst *const env, t_token const *token)
-	__attribute__((nonnull (1)));
-int	builtin_pwd(t_env_lst *const env, t_token const *token)
-	__attribute__((nonnull (1)));
-int	builtin_unset(t_env_lst *const env, t_token const *token)
-	__attribute__((nonnull (1)));
+void	builtin_cd(t_env_lst *const env, t_token const *token)
+		__attribute__((nonnull (1)));
+void	builtin_echo(t_env_lst *const env, t_token const *token)
+		__attribute__((nonnull (1)));
+void	builtin_env(t_env_lst *const env, t_token const *token)
+		__attribute__((nonnull (1)));
+void	builtin_exit(t_env_lst *const env, t_token const *token)
+		__attribute__((nonnull (1)));
+void	builtin_export(t_env_lst *const env, t_token const *token)
+		__attribute__((nonnull (1)));
+void	builtin_pwd(t_env_lst *const env, t_token const *token)
+		__attribute__((nonnull (1)));
+void	builtin_unset(t_env_lst *const env, t_token const *token)
+		__attribute__((nonnull (1)));
 
 static t_builtin const		g_builtin[] = {
 {"cd", builtin_cd},

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/09 12:55:28 by mcourtoi          #+#    #+#             */
-/*   Updated: 2023/04/03 06:11:39 by jodufour         ###   ########.fr       */
+/*   Updated: 2023/04/03 06:56:53 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -103,7 +103,8 @@ int		run(t_shell *const shell)
 
 int		canonicalize(char *const curpath)
 		__attribute__((nonnull));
-int		surprise(void);
+
+void	surprise(void);
 
 bool	is_directory(char const *const pathname)
 		__attribute__((nonnull));

--- a/src/builtin/cd/core.c
+++ b/src/builtin/cd/core.c
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/10 16:04:44 by jodufour          #+#    #+#             */
-/*   Updated: 2023/04/03 05:27:39 by jodufour         ###   ########.fr       */
+/*   Updated: 2023/04/03 06:45:22 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -144,24 +144,32 @@ inline static int	__goto_specific_directory(
  * 
  * @param	env The linked list containing the environment variables.
  * @param	token The first node of the linked list containing the arguments.
- * 
- * @return	EXIT_SUCCESS, or EXIT_FAILURE if a fatal error occured.
  */
-int	builtin_cd(t_env_lst *const env, t_token const *token)
+void	builtin_cd(t_env_lst *const env, t_token const *token)
 {
 	uint8_t	opt;
 	t_env	*node;
 
 	if (__get_opt(&token, &opt))
-		return (g_exit_code = 1U, invalid_option_error("cd", token->str));
+	{
+		g_exit_code = 1U;
+		invalid_option_error("cd", token->str);
+		return ;
+	}
 	if (token)
 	{
 		if (token->next)
-			return (too_many_arguments_error("cd"));
-		return (__goto_specific_directory(env, token->str));
+			too_many_arguments_error("cd");
+		else
+			__goto_specific_directory(env, token->str);
+		return ;
 	}
 	node = env_lst_get_one(env, "HOME");
 	if (!node || !*node->value)
-		return (g_exit_code = 1U, home_not_set_error("cd"));
-	return (__goto_specific_directory(env, node->value));
+	{
+		g_exit_code = 1U;
+		home_not_set_error("cd");
+		return ;
+	}
+	__goto_specific_directory(env, node->value);
 }

--- a/src/builtin/echo/core.c
+++ b/src/builtin/echo/core.c
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/10 16:33:56 by jodufour          #+#    #+#             */
-/*   Updated: 2023/04/03 05:30:22 by jodufour         ###   ########.fr       */
+/*   Updated: 2023/04/03 06:49:49 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -79,6 +79,12 @@ inline static void	__get_opt(t_token const **const token, uint8_t *const opt)
 	}
 }
 
+inline static void	__write_error(void)
+{
+	g_exit_code = 1U;
+	perror("echo: write()");
+}
+
 /**
  * @brief	Print the given arguments to the standard output.
  * 			If an unknown option is given, it shall be considered
@@ -90,10 +96,8 @@ inline static void	__get_opt(t_token const **const token, uint8_t *const opt)
  * 
  * @param	env The linked list containing the environment variables.
  * @param	token The first node of the linked list containing the arguments.
- * 
- * @return	EXIT_SUCCESS, or EXIT_FAILURE if a fatal error occured.
  */
-int	builtin_echo(
+void	builtin_echo(
 	t_env_lst *const env __attribute__((unused)),
 	t_token const *token)
 {
@@ -103,12 +107,11 @@ int	builtin_echo(
 	while (token)
 	{
 		if (write(STDOUT_FILENO, token->str, ft_strlen(token->str)) == -1)
-			return (g_exit_code = 1U, perror("echo: write()"), EXIT_FAILURE);
+			return (__write_error());
 		token = token->next;
 		if (token && write(STDOUT_FILENO, " ", 1LU) == -1)
-			return (g_exit_code = 1U, perror("echo: write()"), EXIT_FAILURE);
+			return (__write_error());
 	}
 	if (!(opt & 1 << OPT_N) && write(STDOUT_FILENO, "\n", 1LU) == -1)
-		return (g_exit_code = 1U, perror("echo: write()"), EXIT_FAILURE);
-	return (EXIT_SUCCESS);
+		return (__write_error());
 }

--- a/src/builtin/env/core.c
+++ b/src/builtin/env/core.c
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/10 16:34:59 by jodufour          #+#    #+#             */
-/*   Updated: 2023/04/02 04:04:00 by jodufour         ###   ########.fr       */
+/*   Updated: 2023/04/03 06:50:49 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -88,17 +88,21 @@ inline static int	__get_opt(t_token const **const token, uint8_t *const opt)
  * 
  * @param	env The linked list containing the environment variables.
  * @param	token The first node of the linked list containing the arguments.
- * 
- * @return	EXIT_SUCCESS, or EXIT_FAILURE if a fatal error occured.
  */
-int	builtin_env(t_env_lst *const env, t_token const *token)
+void	builtin_env(t_env_lst *const env, t_token const *token)
 {
 	uint8_t	opt;
 
 	if (__get_opt(&token, &opt))
-		return (g_exit_code = 125U, invalid_option_error("env", token->str));
+	{
+		g_exit_code = 125U;
+		invalid_option_error("env", token->str);
+		return ;
+	}
 	if (token)
-		return (too_many_arguments_error("env"));
+	{
+		too_many_arguments_error("env");
+		return ;
+	}
 	env_lst_print_assigned(env);
-	return (EXIT_SUCCESS);
 }

--- a/src/builtin/exit/core.c
+++ b/src/builtin/exit/core.c
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/10 16:35:23 by jodufour          #+#    #+#             */
-/*   Updated: 2023/04/02 04:04:19 by jodufour         ###   ########.fr       */
+/*   Updated: 2023/04/03 07:02:33 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,14 +46,12 @@ inline static bool	__is_positive(char const *str)
  * 
  * @param	env The linked list containing the environment variables.
  * @param	token The first node of the linked list containing the arguments.
- * 
- * @return	The function calls `exit()`, and therefore never returns,
- * 			except if an error occured, and then EXIT_FAILURE is returned.
  */
-int	builtin_exit(t_env_lst *const env, t_token const *token)
+void	builtin_exit(t_env_lst *const env, t_token const *token)
 {
-	if (!env_lst_get_one(env, "QUIET_EXIT"))
-		ft_putstr_fd("exit\n", STDERR_FILENO);
+	if (!env_lst_get_one(env, "QUIET_EXIT")
+		&& ft_putstr_fd("exit\n", STDERR_FILENO) == -1)
+		return (perror("exit: ft_pustr_fd"));
 	if (!token)
 		exit(g_exit_code);
 	if (!__is_positive(token->str))
@@ -63,6 +61,9 @@ int	builtin_exit(t_env_lst *const env, t_token const *token)
 		exit(2);
 	}
 	if (token->next)
-		return (too_many_arguments_error("exit"));
+	{
+		too_many_arguments_error("exit");
+		return ;
+	}
 	exit(ft_atohhu(token->str));
 }

--- a/src/builtin/export/core.c
+++ b/src/builtin/export/core.c
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/10 16:35:47 by jodufour          #+#    #+#             */
-/*   Updated: 2023/04/02 00:07:25 by jodufour         ###   ########.fr       */
+/*   Updated: 2023/04/03 06:53:59 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,10 +91,8 @@ inline static int	__get_opt(t_token const **const token, uint8_t *const opt)
  * 
  * @param	env The linked list containing the environment variables.
  * @param	token The first node of the linked list containing the arguments. 
- * 
- * @return	EXIT_SUCCESS, or EXIT_FAILURE if a fatal error occured.
  */
-int	builtin_export(t_env_lst *const env, t_token const *token)
+void	builtin_export(t_env_lst *const env, t_token const *token)
 {
 	uint8_t	opt;
 	bool	is_ok;
@@ -102,15 +100,21 @@ int	builtin_export(t_env_lst *const env, t_token const *token)
 	if (!token)
 		return (surprise());
 	if (__get_opt(&token, &opt))
-		return (g_exit_code = 2U, invalid_option_error("export", token->str));
+	{
+		g_exit_code = 2U;
+		invalid_option_error("export", token->str);
+		return ;
+	}
 	is_ok = true;
 	while (token)
 	{
 		if (process_one(env, token->str, &is_ok))
-			return (g_exit_code = 1U, EXIT_FAILURE);
+		{
+			g_exit_code = 1U;
+			return ;
+		}
 		token = token->next;
 	}
 	if (!is_ok)
-		return (g_exit_code = 1U, EXIT_SUCCESS);
-	return (EXIT_SUCCESS);
+		g_exit_code = 1U;
 }

--- a/src/builtin/export/surprise.c
+++ b/src/builtin/export/surprise.c
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/12 16:15:18 by jodufour          #+#    #+#             */
-/*   Updated: 2023/03/12 16:20:30 by jodufour         ###   ########.fr       */
+/*   Updated: 2023/04/03 06:57:37 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,11 +27,9 @@ static char const	g_surprise[] = "\
 /**
  * @brief	This is our own undefined behavior of builtin export
  * 			when called without any argument. Try it yourself! ;D
- * 
- * @return	Always EXIT_SUCCESS.
  */
-int	surprise(void)
+void	surprise(void)
 {
-	printf("%s", g_surprise);
-	return (EXIT_SUCCESS);
+	if (printf("%s", g_surprise) < 0)
+		return (perror("export: printf()"));
 }

--- a/src/builtin/pwd/core.c
+++ b/src/builtin/pwd/core.c
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/10 16:36:01 by jodufour          #+#    #+#             */
-/*   Updated: 2023/04/03 05:31:39 by jodufour         ###   ########.fr       */
+/*   Updated: 2023/04/03 06:41:44 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -88,10 +88,8 @@ inline static int	__get_opt(t_token const **const token, uint8_t *const opt)
  * 
  * @param	env The linked list containing the environment variables.
  * @param	token The first node of the linked list containing the arguments.
- * 
- * @return	EXIT_SUCCESS, or EXIT_FAILURE if an error occured.
  */
-int	builtin_pwd(
+void	builtin_pwd(
 	t_env_lst *const env __attribute__((unused)),
 	t_token const *token)
 {
@@ -99,12 +97,22 @@ int	builtin_pwd(
 	uint8_t	opt;
 
 	if (__get_opt(&token, &opt) == EXIT_FAILURE)
-		return (g_exit_code = 2U, invalid_option_error("pwd", token->str));
+	{
+		g_exit_code = 2U;
+		invalid_option_error("pwd", token->str);
+		return ;
+	}
 	cwd = getcwd(NULL, 0);
 	if (!cwd)
-		return (g_exit_code = 1U, perror("pwd: getcwd()"), EXIT_FAILURE);
+	{
+		g_exit_code = 1U;
+		perror("pwd: getcwd()");
+		return ;
+	}
 	if (printf("%s\n", cwd) < 0)
-		return (g_exit_code = 1U, free(cwd), perror("pwd: printf()"),
-			EXIT_FAILURE);
-	return (free(cwd), EXIT_SUCCESS);
+	{
+		g_exit_code = 1U;
+		perror("pwd: printf()");
+	}
+	free(cwd);
 }

--- a/src/builtin/unset/core.c
+++ b/src/builtin/unset/core.c
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/10 16:36:19 by jodufour          #+#    #+#             */
-/*   Updated: 2023/04/02 00:07:44 by jodufour         ###   ########.fr       */
+/*   Updated: 2023/04/03 06:55:09 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -89,16 +89,18 @@ inline static int	__get_opt(t_token const **const token, uint8_t *const opt)
  * 
  * @param	env The linked list containing the environment variables.
  * @param	token The first node of the linked list containing the arguments.
- * 
- * @return	EXIT_SUCCESS, or EXIT_FAILURE if an error occured.
  */
-int	builtin_unset(t_env_lst *const env, t_token const *token)
+void	builtin_unset(t_env_lst *const env, t_token const *token)
 {
 	uint8_t	opt;
 	t_env	*node;
 
 	if (__get_opt(&token, &opt) == EXIT_FAILURE)
-		return (g_exit_code = 2U, invalid_option_error("unset", token->str));
+	{
+		g_exit_code = 2U;
+		invalid_option_error("unset", token->str);
+		return ;
+	}
 	while (token)
 	{
 		node = env_lst_get_one(env, token->str);
@@ -106,5 +108,4 @@ int	builtin_unset(t_env_lst *const env, t_token const *token)
 			env_lst_del_one(env, node);
 		token = token->next;
 	}
-	return (EXIT_SUCCESS);
 }

--- a/src/exec/core.c
+++ b/src/exec/core.c
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/23 23:08:53 by jodufour          #+#    #+#             */
-/*   Updated: 2023/04/03 06:11:47 by jodufour         ###   ########.fr       */
+/*   Updated: 2023/04/03 06:58:28 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,10 +64,8 @@ inline static int	__execute_in_place(t_shell *const shell)
 	while (g_builtin[i].name
 		&& ft_strcmp(g_builtin[i].name, shell->tokens.head->str))
 		++i;
-	if (g_builtin[i].func
-		&& g_builtin[i].func(&shell->env, shell->tokens.head->next))
-		return (__restore_std(STDOUT_FILENO, &shell->stdout_backup,
-				EXIT_FAILURE));
+	if (g_builtin[i].func)
+		g_builtin[i].func(&shell->env, shell->tokens.head->next);
 	return (__restore_std(STDOUT_FILENO, &shell->stdout_backup, EXIT_SUCCESS));
 }
 

--- a/src/exec/pipeline.c
+++ b/src/exec/pipeline.c
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/04/03 01:10:16 by jodufour          #+#    #+#             */
-/*   Updated: 2023/04/03 06:12:36 by jodufour         ###   ########.fr       */
+/*   Updated: 2023/04/03 07:03:10 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -107,9 +107,9 @@ int	pipeline(t_shell *const shell, t_token const *node)
 		if (dup2(pds[0], STDIN_FILENO) == -1)
 			return (g_exit_code = 1U, close(pds[0]), close(pds[1]),
 				pid_lst_kill(&shell->pids, SIGTERM), perror("dup2()"),
-					EXIT_FAILURE);
+				EXIT_FAILURE);
 		if (close(pds[0]) || close(pds[1]))
-			return (g_exit_code = 1U,pid_lst_kill(&shell->pids, SIGTERM),
+			return (g_exit_code = 1U, pid_lst_kill(&shell->pids, SIGTERM),
 				perror("close()"), EXIT_FAILURE);
 		token_lst_del_range(&shell->tokens, shell->tokens.head, node->next);
 		node = token_lst_find_first_by_type(&shell->tokens, T_PIPE);

--- a/src/exec/run.c
+++ b/src/exec/run.c
@@ -6,7 +6,7 @@
 /*   By: jodufour <jodufour@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/26 00:12:56 by jodufour          #+#    #+#             */
-/*   Updated: 2023/04/03 05:48:01 by jodufour         ###   ########.fr       */
+/*   Updated: 2023/04/03 07:00:17 by jodufour         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,8 @@ inline static int	__run_builtin(t_shell *const shell)
 	i = 0U;
 	while (ft_strcmp(shell->tokens.head->str, g_builtin[i].name))
 		++i;
-	return (g_builtin[i].func(&shell->env, shell->tokens.head->next));
+	return (g_builtin[i].func(&shell->env, shell->tokens.head->next),
+		EXIT_SUCCESS);
 }
 
 /**


### PR DESCRIPTION
The made changes are related to the issue https://github.com/Saphirac/minishell/issues/45.
After thinking about it, it is a better idea to prevent ANY error from exiting the shell instead of only errors due to a call to `getcwd()` that may have failed. Therefore, none of the builtins returns a value now, but they still update the update status correctly, and output the errors they encountered if any.